### PR TITLE
improve functions and add call-import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 cirru_parser = "0.1.1"
 regex = "1"
 lazy_static = "1.4.0"
+
+[profile.release]
+debug = true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For binary op, top value puts on right.
 | (BlockEnd)           | internal mark for ending a block                        | Internal          |
 | `echo`               | pop value from stack and print                          |                   |
 | `call $f`            | call function `$f`                                      |                   |
+| `call-import $f`     | call imported function `$f`                             |                   |
 | `unreachable`        | throw unreachable panic                                 |                   |
 | `nop`                | No op                                                   |                   |
 | `quit $code`         | quit program and return exit code `$code`               |                   |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For binary op, top value puts on right.
 | `local.get $idx`  | get value at `$idx` load on stack                       |             |
 | `global.set $idx` | set global value at `$idx`                              |             |
 | `global.get $idx` | get global value at `$idx`                              |             |
-| `load $v`         | load value `$v` on stack                                |             |
+| `const $v`        | push value `$v` on stack                                |             |
 | `dup`             | duplicate top value on stack                            |             |
 | `drop`            | drop top value from stack                               |             |
 | `i.add`           | add two i64 numbers on stack into one                   |             |
@@ -55,7 +55,7 @@ For binary op, top value puts on right.
 | `loop`            | declare a loop block                                    |             |
 | (BlockEnd)        | internal mark for ending a block                        | Internal    |
 | `echo`            | pop value from stack and print                          |             |
-| `call $f $size`   | call function `$f` with `$size` params                  |             |
+| `call $f`         | call function `$f`                                      |             |
 | `unreachable`     | throw unreachable panic                                 |             |
 | `nop`             | No op                                                   |             |
 | `quit $code`      | quit program and return exit code `$code`               |             |

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ For binary op, top value puts on right.
 For `$types`, it can be `($t1 $t2 -> $t3 $t4)`, where supported types are:
 
 - nil
-- i32
 - i64
+- f64
 - bool _TODO_
 - str _TODO_
 - list _TODO_

--- a/README.md
+++ b/README.md
@@ -15,51 +15,62 @@ Highly inspired by:
 
 For binary op, top value puts on right.
 
-| Code              | Usage                                                   | Note        |
-| ----------------- | ------------------------------------------------------- | ----------- |
-| `local`           | new local variable                                      | (not ready) |
-| `local.set $idx`  | set value at `$idx`                                     |             |
-| `local.tee $idx`  | set value at `$idx`, and also load it                   |             |
-| `local.get $idx`  | get value at `$idx` load on stack                       |             |
-| `global.set $idx` | set global value at `$idx`                              |             |
-| `global.get $idx` | get global value at `$idx`                              |             |
-| `const $v`        | push value `$v` on stack                                |             |
-| `dup`             | duplicate top value on stack                            |             |
-| `drop`            | drop top value from stack                               |             |
-| `i.add`           | add two i64 numbers on stack into one                   |             |
-| `i.mul`           | multiply two i64 numbers on stack into one              |             |
-| `i.div`           | divide two i64 numbers on stack into one                |             |
-| `i.rem`           | calculate reminder two i64 numbers on stack into one    |             |
-| `i.neg`           | negate i64 numbers on top of stack                      |             |
-| `i.shr $bits`     | call SHR `$bits` bits on i64 numbers on top of stack    |             |
-| `i.shl $bits`     | call SHL `$bits` bits on i64 numbers on top of stack    |             |
-| `i.eq`            | detects if two i64 numbers on stack equal               |             |
-| `i.ne`            | detects if two i64 numbers on stack not equal           |             |
-| `i.lt`            | litter than, compares two i64 numbers on stack          |             |
-| `i.gt`            | greater than, compares two i64 numbers on stack         |             |
-| `i.le`            | litter/equal than, compares two i64 numbers on stack    |             |
-| `i.ge`            | greater/equal than, compares two i64 numbers on stack   |             |
-| `add`             | add two f64 numbers on stack into one                   |             |
-| `mul`             | multiply two f64 numbers on stack into one              |             |
-| `div`             | divide two f64 numbers on stack into one                |             |
-| `neg`             | negate f64 numbers on top of stack                      |             |
-| `list.new`        |                                                         | TODO        |
-| `list.get`        |                                                         | TODO        |
-| `list.set`        |                                                         | TODO        |
-| `link.new`        |                                                         | TODO        |
-| `and`             |                                                         | TODO        |
-| `or`              |                                                         | TODO        |
-| `br $n`           | break `$n` level of block, 0 means end of current block |             |
-| `br-if $n`        | like `br $n` but detects top value on stack first       |
-| `block`           | declare a block                                         |             |
-| `loop`            | declare a loop block                                    |             |
-| (BlockEnd)        | internal mark for ending a block                        | Internal    |
-| `echo`            | pop value from stack and print                          |             |
-| `call $f`         | call function `$f`                                      |             |
-| `unreachable`     | throw unreachable panic                                 |             |
-| `nop`             | No op                                                   |             |
-| `quit $code`      | quit program and return exit code `$code`               |             |
-| `return`          |                                                         | TODO        |
+| Code                 | Usage                                                   | Note              |
+| -------------------- | ------------------------------------------------------- | ----------------- |
+| `local`              | new local variable                                      | (not ready)       |
+| `local.set $idx`     | set value at `$idx`                                     |                   |
+| `local.tee $idx`     | set value at `$idx`, and also load it                   |                   |
+| `local.get $idx`     | get value at `$idx` load on stack                       |                   |
+| `global.set $idx`    | set global value at `$idx`                              |                   |
+| `global.get $idx`    | get global value at `$idx`                              |                   |
+| `const $v`           | push value `$v` on stack                                |                   |
+| `dup`                | duplicate top value on stack                            |                   |
+| `drop`               | drop top value from stack                               |                   |
+| `i.add`              | add two i64 numbers on stack into one                   |                   |
+| `i.mul`              | multiply two i64 numbers on stack into one              |                   |
+| `i.div`              | divide two i64 numbers on stack into one                |                   |
+| `i.rem`              | calculate reminder two i64 numbers on stack into one    |                   |
+| `i.neg`              | negate i64 numbers on top of stack                      |                   |
+| `i.shr $bits`        | call SHR `$bits` bits on i64 numbers on top of stack    |                   |
+| `i.shl $bits`        | call SHL `$bits` bits on i64 numbers on top of stack    |                   |
+| `i.eq`               | detects if two i64 numbers on stack equal               |                   |
+| `i.ne`               | detects if two i64 numbers on stack not equal           |                   |
+| `i.lt`               | litter than, compares two i64 numbers on stack          |                   |
+| `i.gt`               | greater than, compares two i64 numbers on stack         |                   |
+| `i.le`               | litter/equal than, compares two i64 numbers on stack    |                   |
+| `i.ge`               | greater/equal than, compares two i64 numbers on stack   |                   |
+| `add`                | add two f64 numbers on stack into one                   |                   |
+| `mul`                | multiply two f64 numbers on stack into one              |                   |
+| `div`                | divide two f64 numbers on stack into one                |                   |
+| `neg`                | negate f64 numbers on top of stack                      |                   |
+| `list.new`           |                                                         | TODO              |
+| `list.get`           |                                                         | TODO              |
+| `list.set`           |                                                         | TODO              |
+| `link.new`           |                                                         | TODO              |
+| `and`                |                                                         | TODO              |
+| `or`                 |                                                         | TODO              |
+| `br $n`              | break `$n` level of block, 0 means end of current block |                   |
+| `br-if $n`           | like `br $n` but detects top value on stack first       |
+| `block $types $body` | declare a block                                         |                   |
+| `loop $types $body`  | declare a loop block                                    |                   |
+| (BlockEnd)           | internal mark for ending a block                        | Internal          |
+| `echo`               | pop value from stack and print                          |                   |
+| `call $f`            | call function `$f`                                      |                   |
+| `unreachable`        | throw unreachable panic                                 |                   |
+| `nop`                | No op                                                   |                   |
+| `quit $code`         | quit program and return exit code `$code`               |                   |
+| `return`             |                                                         | TODO              |
+| `fn $types $body`    |                                                         | Global definition |
+
+For `$types`, it can be `($t1 $t2 -> $t3 $t4)`, where supported types are:
+
+- nil
+- i32
+- i64
+- bool _TODO_
+- str _TODO_
+- list _TODO_
+- link _TODO_
 
 ### License
 

--- a/examples/demo.cirru
+++ b/examples/demo.cirru
@@ -9,9 +9,10 @@ fn demo (-> i64)
     block (->) (const 1.) (const 2.) (neg) (add) (echo)
       block (->) (const 1.) (const 2.) (neg) (add) (echo)
   const "|======"
+  echo
   block (->) (br 0) (const 1.) (const 2.) (neg) (add) (echo)
   , (const "|demo of string") (echo)
-  block (->)
+  block (-> i64)
     const 0
     local.set 0
     const 0
@@ -32,11 +33,11 @@ fn demo (-> i64)
   local.get 0
   echo
 
-fn main ()
+fn main (-> i64)
   const "|loading program"
   echo
 
-  const 2
+  ;; const 2
   call demo
 
   return

--- a/examples/demo.cirru
+++ b/examples/demo.cirru
@@ -37,7 +37,11 @@ fn main (-> i64)
   const "|loading program"
   echo
 
-  ;; const 2
   call demo
+
+  const 2
+  const 3
+  call-import log2
+  echo
 
   return

--- a/examples/demo.cirru
+++ b/examples/demo.cirru
@@ -1,21 +1,21 @@
 
-fn f1 () (const "|data in f1") (echo) (const 10) (return)
+fn f1 (-> i64) (const "|data in f1") (echo) (const 10) (return)
 
-fn f2 (i64) (local.get 0) (echo) (const 10) (return)
+fn f2 (i64 -> i64) (local.get 0) (echo) (const 10) (return)
 
-fn demo ()
+fn demo (-> i64)
   , (const 1) (echo) (const 4.) (const 2.) (add) (echo)
-  block (br 0) (const 1.) (const 2.) (neg) (add) (echo)
-    block (const 1.) (const 2.) (neg) (add) (echo)
-      block (const 1.) (const 2.) (neg) (add) (echo)
+  block (->) (br 0) (const 1.) (const 2.) (neg) (add) (echo)
+    block (->) (const 1.) (const 2.) (neg) (add) (echo)
+      block (->) (const 1.) (const 2.) (neg) (add) (echo)
   const "|======"
-  block (br 0) (const 1.) (const 2.) (neg) (add) (echo)
+  block (->) (br 0) (const 1.) (const 2.) (neg) (add) (echo)
   , (const "|demo of string") (echo)
-  block
+  block (->)
     const 0
     local.set 0
     const 0
-    loop
+    loop (i64 -> i64)
       const 1
       i.add
       dup

--- a/examples/demo.cirru
+++ b/examples/demo.cirru
@@ -1,32 +1,42 @@
 
-fn f1 () (load 1) (echo)
+fn f1 () (const "|data in f1") (echo) (const 10) (return)
 
-fn main ()
-  , (load 1) (echo) (load 4.) (load 2.) (add) (echo)
-  block (br 0) (load 1.) (load 2.) (neg) (add) (echo)
-    block (load 1.) (load 2.) (neg) (add) (echo)
-      block (load 1.) (load 2.) (neg) (add) (echo)
-  load "|======"
-  block (br 0) (load 1.) (load 2.) (neg) (add) (echo)
-  , (load "|demo of string") (echo)
+fn f2 (i64) (local.get 0) (echo) (const 10) (return)
+
+fn demo ()
+  , (const 1) (echo) (const 4.) (const 2.) (add) (echo)
+  block (br 0) (const 1.) (const 2.) (neg) (add) (echo)
+    block (const 1.) (const 2.) (neg) (add) (echo)
+      block (const 1.) (const 2.) (neg) (add) (echo)
+  const "|======"
+  block (br 0) (const 1.) (const 2.) (neg) (add) (echo)
+  , (const "|demo of string") (echo)
   block
-    load 0
+    const 0
     local.set 0
-    load 0
+    const 0
     loop
-      load 1
+      const 1
       i.add
       dup
       local.get 0
       i.add
       local.set 0
       dup
-      load 100000
+      const 100000
       i.ge
       br-if 1
       br 0
-  load "|check sum"
+  const "|check sum"
   echo
   local.get 0
   echo
-  quit 0
+
+fn main ()
+  const "|loading program"
+  echo
+
+  const 2
+  call demo
+
+  return

--- a/src/bin/calx.rs
+++ b/src/bin/calx.rs
@@ -1,8 +1,14 @@
+use std::collections::hash_map::HashMap;
 use std::fs;
 
 use cirru_parser::{parse, Cirru};
 
-use calx_vm::{parse_function, CalxFunc, CalxVM};
+use calx_vm::{parse_function, Calx, CalxFunc, CalxImportsDict, CalxVM};
+
+fn log2_calx_value(xs: Vec<Calx>) -> Result<Calx, String> {
+  println!("log: {:?}", xs);
+  Ok(Calx::Nil)
+}
 
 fn main() -> Result<(), String> {
   let contents = fs::read_to_string("examples/demo.cirru").expect("Cirru file for instructions");
@@ -19,7 +25,10 @@ fn main() -> Result<(), String> {
       }
     }
 
-    let mut vm = CalxVM::new(fns, vec![]);
+    let mut imports: CalxImportsDict = HashMap::new();
+    imports.insert(String::from("log2"), (log2_calx_value, 2));
+
+    let mut vm = CalxVM::new(fns, vec![], imports);
 
     // for func in vm.funcs.to_owned() {
     //   println!("loaded fn: {}", func);

--- a/src/bin/calx.rs
+++ b/src/bin/calx.rs
@@ -26,13 +26,14 @@ fn main() -> Result<(), String> {
     // }
 
     match vm.run() {
-      Ok(v) => {
-        println!("Result: {}", v);
+      Ok(()) => {
+        println!("Result: {:?}", vm.stack);
         Ok(())
       }
       Err(e) => {
         println!("VM state: {:?}", vm.stack);
-        Err(e)
+        println!("{}", e);
+        Err(String::from("Failed to run"))
       }
     }
   } else {

--- a/src/bin/calx.rs
+++ b/src/bin/calx.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use cirru_parser::{parse, Cirru};
 
-use calx_vm::{parse_function, Calx, CalxFrame, CalxFunc, CalxVM};
+use calx_vm::{parse_function, CalxFunc, CalxVM};
 
 fn main() -> Result<(), String> {
   let contents = fs::read_to_string("examples/demo.cirru").expect("Cirru file for instructions");
@@ -21,12 +21,15 @@ fn main() -> Result<(), String> {
 
     let mut vm = CalxVM::new(fns, vec![]);
 
-    for func in vm.funcs.to_owned() {
-      println!("loaded fn: {}", func);
-    }
+    // for func in vm.funcs.to_owned() {
+    //   println!("loaded fn: {}", func);
+    // }
 
-    match vm.run(0, vec![]) {
-      Ok(_) => Ok(()),
+    match vm.run() {
+      Ok(v) => {
+        println!("Result: {}", v);
+        Ok(())
+      }
       Err(e) => {
         println!("VM state: {:?}", vm.stack);
         Err(e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,4 @@ mod vm;
 
 pub use parser::parse_function;
 pub use primes::{Calx, CalxFrame, CalxFunc};
-pub use vm::CalxVM;
+pub use vm::{CalxImportsDict, CalxVM};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -232,6 +232,10 @@ pub fn parse_instr(ptr_base: usize, node: &Cirru) -> Result<Vec<CalxInstr>, Stri
           }
           "unreachable" => Ok(vec![CalxInstr::Unreachable]),
           "nop" => Ok(vec![CalxInstr::Nop]),
+          ";;" => {
+            // commenOk
+            Ok(vec![])
+          }
           "quit" => {
             if xs.len() != 2 {
               return Err(format!("quit expected a position, {:?}", xs));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -230,6 +230,18 @@ pub fn parse_instr(ptr_base: usize, node: &Cirru) -> Result<Vec<CalxInstr>, Stri
 
             Ok(vec![CalxInstr::Call(name)])
           }
+          "call-import" => {
+            let name: String;
+            if xs.len() != 2 {
+              return Err(format!("call expected function name, {:?}", xs));
+            }
+            match &xs[1] {
+              Cirru::Leaf(s) => name = s.to_owned(),
+              Cirru::List(_) => return Err(format!("expected a name, got {:?}", xs[1])),
+            }
+
+            Ok(vec![CalxInstr::CallImport(name)])
+          }
           "unreachable" => Ok(vec![CalxInstr::Unreachable]),
           "nop" => Ok(vec![CalxInstr::Nop]),
           ";;" => {

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -90,7 +90,7 @@ pub enum CalxInstr {
   LocalGet(usize),
   GlobalSet(usize),
   GlobalGet(usize),
-  Load(Calx),
+  Const(Calx),
   Dup,
   Drop,
   // number operations
@@ -139,7 +139,7 @@ pub enum CalxInstr {
   BlockEnd,
   /// TODO use function name at first
   Echo, // pop and println current value
-  Call(String, usize), // during running, only use index,
+  Call(String), // during running, only use index,
   Unreachable,
   Nop,
   Quit(usize), // quit and return value

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -61,14 +61,15 @@ impl fmt::Display for Calx {
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct CalxFunc {
   pub name: String,
-  pub params_type: Vec<CalxType>,
+  pub params_types: Vec<CalxType>,
+  pub ret_types: Vec<CalxType>,
   pub instrs: Vec<CalxInstr>,
 }
 
 impl fmt::Display for CalxFunc {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.write_str("CalxFunc (")?;
-    for p in &self.params_type {
+    for p in &self.params_types {
       write!(f, "{:?} ", p)?;
     }
     f.write_str(")")?;
@@ -132,6 +133,8 @@ pub enum CalxInstr {
   BrIf(usize),
   Block {
     // bool oo to indicate loop
+    params_types: Vec<CalxType>,
+    ret_types: Vec<CalxType>,
     looped: bool,
     from: usize,
     to: usize,
@@ -156,6 +159,8 @@ pub struct CalxError {
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct BlockData {
   pub looped: bool,
+  pub params_types: Vec<CalxType>,
+  pub ret_types: Vec<CalxType>,
   pub from: usize,
   pub to: usize,
 }

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -142,7 +142,8 @@ pub enum CalxInstr {
   BlockEnd,
   /// TODO use function name at first
   Echo, // pop and println current value
-  Call(String), // during running, only use index,
+  Call(String),       // during running, only use index,
+  CallImport(String), // TODO,
   Unreachable,
   Nop,
   Quit(usize), // quit and return value

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -163,6 +163,7 @@ pub struct BlockData {
   pub ret_types: Vec<CalxType>,
   pub from: usize,
   pub to: usize,
+  pub initial_stack_size: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
@@ -172,6 +173,7 @@ pub struct CalxFrame {
   pub pointer: usize,
   pub initial_stack_size: usize,
   pub blocks_track: Vec<BlockData>,
+  pub ret_types: Vec<CalxType>,
 }
 
 impl CalxFrame {
@@ -182,6 +184,23 @@ impl CalxFrame {
       pointer: 0,
       initial_stack_size: 0,
       blocks_track: vec![],
+      ret_types: vec![],
     }
+  }
+}
+
+impl fmt::Display for CalxFrame {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("CalxFrame ")?;
+    write!(f, "@{} (", self.initial_stack_size)?;
+    for p in &self.ret_types {
+      write!(f, "{:?} ", p)?;
+    }
+    f.write_str(")")?;
+    for (idx, instr) in self.instrs.iter().enumerate() {
+      write!(f, "\n  {:02} {:?}", idx, instr)?;
+    }
+    f.write_str("\n")?;
+    Ok(())
   }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -371,12 +371,19 @@ impl CalxVM {
             continue; // point reset, goto next loop
           }
         }
-        CalxInstr::Block { looped, from, to } => {
-          self
-            .top_frame
-            .blocks_track
-            .push(BlockData { looped, from, to })
-        }
+        CalxInstr::Block {
+          looped,
+          from,
+          to,
+          params_types,
+          ret_types,
+        } => self.top_frame.blocks_track.push(BlockData {
+          looped,
+          params_types,
+          ret_types,
+          from,
+          to,
+        }),
         CalxInstr::BlockEnd => {
           self.top_frame.blocks_track.pop();
         }
@@ -388,7 +395,7 @@ impl CalxVM {
           match find_func(&self.funcs, &f_name) {
             Some(f) => {
               let mut locals: Vec<Calx> = vec![];
-              for _ in 0..f.params_type.len() {
+              for _ in 0..f.params_types.len() {
                 let v = self.stack_pop()?;
                 locals.insert(0, v);
               }
@@ -402,7 +409,7 @@ impl CalxVM {
               };
 
               // TODO check params type
-              println!("TODO check args: {:?}", f.params_type);
+              println!("TODO check args: {:?}", f.params_types);
 
               // start in new frame
               continue;


### PR DESCRIPTION
Now function is declared with types(although only arity and stack size are being checked):

```cirru
fn f2 (i64 -> i64) (local.get 0) (echo) (const 10) (return)
```

Also trying `call-import`.
