### PR TITLE
initial support for generating binary and evaluating from binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calx_vm"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -16,10 +16,11 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_parser = "0.1.17"
-regex = "1.5.4"
+cirru_parser = "0.1.23"
+regex = "1.6.0"
 lazy_static = "1.4.0"
-clap = "3.1.5"
+clap = "3.2.12"
+bincode = "2.0.0-rc.1"
 
 [profile.release]
 debug = true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ calx -S hello.cirru
 calx -D hello.cirru
 ```
 
+`--emit-binary filename` for encode functions into a binary file.
+
+`--eval-binary` for reading a binary input file to run.
+
 ### Syntax Sugar
 
 Code of:

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,7 @@ pub fn parse_function(nodes: &[Cirru]) -> Result<CalxFunc, String> {
   }
 
   Ok(CalxFunc {
-    name,
+    name: name.to_string(),
     params_types,
     ret_types,
     instrs: body,
@@ -210,7 +210,7 @@ pub fn parse_instr(ptr_base: usize, node: &Cirru) -> Result<Vec<CalxInstr>, Stri
               Cirru::List(_) => return Err(format!("expected a name, got {:?}", xs[1])),
             };
 
-            Ok(vec![CalxInstr::Call(name)])
+            Ok(vec![CalxInstr::Call((*name).to_owned())])
           }
           "call-import" => {
             if xs.len() != 2 {
@@ -221,7 +221,7 @@ pub fn parse_instr(ptr_base: usize, node: &Cirru) -> Result<Vec<CalxInstr>, Stri
               Cirru::List(_) => return Err(format!("expected a name, got {:?}", xs[1])),
             };
 
-            Ok(vec![CalxInstr::CallImport(name)])
+            Ok(vec![CalxInstr::CallImport((*name).to_owned())])
           }
           "unreachable" => Ok(vec![CalxInstr::Unreachable]),
           "nop" => Ok(vec![CalxInstr::Nop]),
@@ -252,7 +252,7 @@ pub fn parse_instr(ptr_base: usize, node: &Cirru) -> Result<Vec<CalxInstr>, Stri
               Cirru::List(_) => return Err(format!("assert expected a message, got {:?}", xs[1])),
             };
 
-            Ok(vec![CalxInstr::Assert(message)])
+            Ok(vec![CalxInstr::Assert((*message).to_owned())])
           }
           _ => Err(format!("unknown instruction: {}", name)),
         },

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -6,10 +6,11 @@
  * (I'm not equiped enough for building a bytecode VM yet...)
  */
 
+use bincode::{Decode, Encode};
 use std::fmt;
 
 /// Simplied from Calcit, but trying to be basic and mutable
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Decode, Encode)]
 pub enum Calx {
   Nil,
   Bool(bool),
@@ -18,10 +19,10 @@ pub enum Calx {
   Str(String),
   List(Vec<Calx>),
   // to simultate linked structures
-  Link(Box<Calx>, Box<Calx>, Box<Calx>),
+  // Link(Box<Calx>, Box<Calx>, Box<Calx>),
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Decode, Encode)]
 pub enum CalxType {
   Nil,
   Bool,
@@ -52,15 +53,14 @@ impl fmt::Display for Calx {
         }
         f.write_str(")")?;
         Ok(())
-      }
-      Calx::Link(..) => f.write_str("TODO LINK"),
+      } // Calx::Link(..) => f.write_str("TODO LINK"),
     }
   }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Encode, Decode)]
 pub struct CalxFunc {
-  pub name: Box<str>,
+  pub name: String,
   pub params_types: Vec<CalxType>,
   pub ret_types: Vec<CalxType>,
   pub instrs: Vec<CalxInstr>,
@@ -86,7 +86,7 @@ impl fmt::Display for CalxFunc {
 }
 
 /// learning from WASM but for dynamic data
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Decode, Encode)]
 pub enum CalxInstr {
   // Param, // load variable from parameter
   LocalSet(usize),
@@ -150,14 +150,14 @@ pub enum CalxInstr {
   /// pop and println current value
   Echo,
   /// TODO use function name at first, during running, only use index,
-  Call(Box<str>),
-  CallImport(Box<str>),
+  Call(String),
+  CallImport(String),
   Unreachable,
   Nop,
   Quit(usize), // quit and return value
   Return,
   /// TODO might also be a foreign function instead
-  Assert(Box<str>),
+  Assert(String),
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]


### PR DESCRIPTION
直接用 https://github.com/bincode-org/bincode 把程序转成二进制存下来了. 不过有个问题是存在 `Box<_>` 的数据, bincode 是不直接支持的, 所以去掉了 `Box<str>` 的用法. 后续可能还是要加上, 所以要再找找 `Box<_>` 相关的方案.

没有解决的一个问题是, 程序结构调整, 出现跨版本 Binary 结构不一致, 怎么办?