### PR TITLE
a toy version of return-call

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,7 @@ jobs:
       - run: cargo run -- -S examples/assert.cirru
       - run: cargo run -- -S examples/nested.cirru
       - run: cargo run -- -S examples/named.cirru
+      - run: cargo run -- examples/recur.cirru
       - run: cargo run -- --emit-binary target/a.calx examples/named.cirru && cargo run -- --eval-binary target/a.calx
 
       # - run: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
       - run: cargo run -- -S examples/assert.cirru
       - run: cargo run -- -S examples/nested.cirru
       - run: cargo run -- -S examples/named.cirru
+      - run: cargo run -- examples/recur.cirru
       - run: cargo run -- --emit-binary target/a.calx examples/named.cirru && cargo run -- --eval-binary target/a.calx
 
       - uses: actions-rs/clippy-check@v1

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Calx Binary Edition `0.1`:
 | (BlockEnd)           | internal mark for ending a block                         | Internal                               |
 | `echo`               | pop value from stack and print                           |                                        |
 | `call $f`            | call function `$f`                                       |                                        |
+| `return-call $f`     | tail call function `$f`                                  |                                        |
 | `call-import $f`     | call imported function `$f`                              |                                        |
 | `unreachable`        | throw unreachable panic                                  |                                        |
 | `nop`                | No op                                                    |                                        |

--- a/examples/recur.cirru
+++ b/examples/recur.cirru
@@ -1,0 +1,24 @@
+
+fn main ()
+  const 0
+  const 100000
+  call sum
+  echo
+
+fn sum (($acc i64) ($x i64) -> i64)
+  local.get $acc
+  local.get $x
+  add
+  ;; dup
+  ;; echo
+  block (->)
+    block (->)
+      local.get $x
+      const 1
+      i.le
+      br-if 1
+    local.get $x
+    const -1
+    add
+    return-call sum
+  return

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,6 +204,17 @@ pub fn parse_instr(ptr_base: usize, node: &Cirru, collector: &mut LocalsCollecto
 
             Ok(vec![CalxInstr::Call((*name).to_owned())])
           }
+          "return-call" => {
+            if xs.len() != 2 {
+              return Err(format!("return-call expected function name, {:?}", xs));
+            }
+            let name: Box<str> = match &xs[1] {
+              Cirru::Leaf(s) => s.to_owned(),
+              Cirru::List(_) => return Err(format!("expected a name, got {:?}", xs[1])),
+            };
+
+            Ok(vec![CalxInstr::ReturnCall((*name).to_owned())])
+          }
           "call-import" => {
             if xs.len() != 2 {
               return Err(format!("call expected function name, {:?}", xs));

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -171,8 +171,10 @@ pub enum CalxInstr {
   BlockEnd(bool),
   /// pop and println current value
   Echo,
-  /// TODO use function name at first, during running, only use index,
+  /// TODO use function name at first, during running, index can be faster
   Call(String),
+  /// for tail recursion
+  ReturnCall(String),
   CallImport(String),
   Unreachable,
   Nop,


### PR DESCRIPTION
inspired by https://leaningtech.com/fantastic-tail-calls-and-how-to-implement-them/ .

Calx does not have checks, so `return-call` is barely a simplified version of `call` that does not increase frames.
